### PR TITLE
Freezing phpstan because of issue with upgrade of nette/bootstrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
         "optimize-autoloader": true
     },
     "require": {
+        "nette/bootstrap": "^2.4.6",
         "brianium/paratest": "v1.1.0",
         "cakephp/bake": "^1.1",
         "cakephp/cakephp-codesniffer": "^3.0",
-        "phpstan/phpstan": "^0.10.3",
-        "phpstan/phpstan-webmozart-assert": "^0.10",
+        "phpstan/phpstan": "0.11.4",
+        "phpstan/phpstan-webmozart-assert": "^0.11",
         "phpunit/phpunit": "^6.0",
         "psy/psysh": "@stable",
         "thecodingmachine/phpstan-strict-rules": "^0.11.0",


### PR DESCRIPTION
Initial problem with major upgrade of `netter/bootstrap` caused some problems with `phpstan/phpstan` package.

Hardcoding phpstan version and downgrading `nette/bootstrap` package, until the problem is resolved.

Reference: https://github.com/phpstan/phpstan/issues/2033