### PR TITLE
Removing PHPStan and nette/di package version freeze

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,10 @@
         "optimize-autoloader": true
     },
     "require": {
-        "nette/bootstrap": "^2.4.6",
         "brianium/paratest": "v1.1.0",
         "cakephp/bake": "^1.1",
         "cakephp/cakephp-codesniffer": "^3.0",
-        "phpstan/phpstan": "0.11.4",
+        "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-webmozart-assert": "^0.11",
         "phpunit/phpunit": "^6.0",
         "psy/psysh": "@stable",


### PR DESCRIPTION
As `nette/di` was patched and `phpstan` issue is resolved, there's no point of freezing the packages.